### PR TITLE
feat: add CustomField support for sales transactions and fix encryption URL bug

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -160,7 +160,7 @@ class QuickbooksClient:
             if params is None:
                 params = {}
             if "minorversion" not in params:
-                params["minorversion"] = "65"
+                params["minorversion"] = "75"
             logging.info(f"Requesting: {url} with params: {params}")
             data = requesting.get(url, headers=headers, params=params)
 

--- a/src/client.py
+++ b/src/client.py
@@ -157,6 +157,10 @@ class QuickbooksClient:
         request_success = False
         while not request_success:
             headers = {"Authorization": "Bearer " + self.access_token, "Accept": "application/json"}
+            if params is None:
+                params = {}
+            if "minorversion" not in params:
+                params["minorversion"] = "65"
             logging.info(f"Requesting: {url} with params: {params}")
             data = requesting.get(url, headers=headers, params=params)
 

--- a/src/component.py
+++ b/src/component.py
@@ -219,7 +219,7 @@ class Component(ComponentBase):
 
     @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
     def encrypt(self, token: str) -> str:
-        url = f"https://encryption.{URL_SUFFIX}.com/encrypt"
+        url = f"https://encryption.{URL_SUFFIX}/encrypt"
         params = {
             "componentId": self.environment_variables.component_id,
             "projectId": self.environment_variables.project_id,

--- a/src/mappings.json
+++ b/src/mappings.json
@@ -1475,6 +1475,37 @@
                     }
                 }
             }
+        },
+        "CustomField": {
+            "type": "table",
+            "destination": "Invoice-CustomField",
+            "tableMapping": {
+                "DefinitionId": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Definition_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Name"
+                    }
+                },
+                "Type": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Type"
+                    }
+                },
+                "StringValue": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "StringValue"
+                    }
+                }
+            }
         }
     },
     "Item": {

--- a/src/mappings.json
+++ b/src/mappings.json
@@ -3445,5 +3445,1256 @@
                     "destination": "time"
                 }
             }
+    },
+    "SalesReceipt": {
+        "Id": {
+            "type": "column",
+            "mapping": {
+                "destination": "ID",
+                "primaryKey": true
+            }
+        },
+        "CustomerRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_ID"
+            }
+        },
+        "CustomerRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_name"
+            }
+        },
+        "DocNumber": {
+            "type": "column",
+            "mapping": {
+                "destination": "DocNumber"
+            }
+        },
+        "TxnDate": {
+            "type": "column",
+            "mapping": {
+                "destination": "TxnDate"
+            }
+        },
+        "CurrencyRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Currency"
+            }
+        },
+        "ExchangeRate": {
+            "type": "column",
+            "mapping": {
+                "destination": "ExchangeRate"
+            }
+        },
+        "GlobalTaxCalculation": {
+            "type": "column",
+            "mapping": {
+                "destination": "GlobalTaxCalculation"
+            }
+        },
+        "TotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "TotalAmount"
+            }
+        },
+        "HomeTotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "HomeTotalAmount"
+            }
+        },
+        "PrintStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "PrintStatus"
+            }
+        },
+        "EmailStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "EmailStatus"
+            }
+        },
+        "BillEmail.Address": {
+            "type": "column",
+            "mapping": {
+                "destination": "BillEmail_Address"
+            }
+        },
+        "Balance": {
+            "type": "column",
+            "mapping": {
+                "destination": "Balance"
+            }
+        },
+        "PaymentMethodRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "PaymentMethod_ID"
+            }
+        },
+        "PaymentMethodRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "PaymentMethod_name"
+            }
+        },
+        "DepositToAccountRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "DepositToAccount_ID"
+            }
+        },
+        "DepositToAccountRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "DepositToAccount_name"
+            }
+        },
+        "BillAddr": {
+            "type": "table",
+            "destination": "SalesReceipt-BillAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "BillAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "ShipAddr": {
+            "type": "table",
+            "destination": "SalesReceipt-ShipAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ShipAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "Line": {
+            "type": "table",
+            "destination": "SalesReceipt-Line",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ID",
+                        "primaryKey": true
+                    }
+                },
+                "LineNum": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "LineNum"
+                    }
+                },
+                "Description": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Description"
+                    }
+                },
+                "Amount": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Amount"
+                    }
+                },
+                "DetailType": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "DetailType"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_ID"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_name"
+                    }
+                },
+                "SalesItemLineDetail.UnitPrice": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "UnitPrice"
+                    }
+                },
+                "SalesItemLineDetail.Qty": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Qty"
+                    }
+                },
+                "SalesItemLineDetail.TaxCodeRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TaxCode"
+                    }
+                }
+            }
+        },
+        "TxnTaxDetail": {
+            "type": "table",
+            "destination": "SalesReceipt-TxnTaxDetail",
+            "tableMapping": {
+                "TotalTax": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TotalTax"
+                    }
+                },
+                "TaxLine": {
+                    "type": "table",
+                    "destination": "SalesReceipt-TxnTaxDetail-TaxLine",
+                    "tableMapping": {
+                        "Amount": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "Amount"
+                            }
+                        },
+                        "DetailType": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "DetailType"
+                            }
+                        },
+                        "TaxLineDetail.TaxRateRef.value": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxRate_ID",
+                                "primaryKey": true
+                            }
+                        },
+                        "TaxLineDetail.TaxPercent": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxPercent"
+                            }
+                        },
+                        "TaxLineDetail.NetAmountTaxable": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "NetAmountTaxable"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "CustomField": {
+            "type": "table",
+            "destination": "SalesReceipt-CustomField",
+            "tableMapping": {
+                "DefinitionId": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Definition_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Name"
+                    }
+                },
+                "Type": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Type"
+                    }
+                },
+                "StringValue": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "StringValue"
+                    }
+                }
+            }
+        }
+    },
+    "Estimate": {
+        "Id": {
+            "type": "column",
+            "mapping": {
+                "destination": "ID",
+                "primaryKey": true
+            }
+        },
+        "CustomerRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_ID"
+            }
+        },
+        "CustomerRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_name"
+            }
+        },
+        "DocNumber": {
+            "type": "column",
+            "mapping": {
+                "destination": "DocNumber"
+            }
+        },
+        "TxnDate": {
+            "type": "column",
+            "mapping": {
+                "destination": "TxnDate"
+            }
+        },
+        "ExpirationDate": {
+            "type": "column",
+            "mapping": {
+                "destination": "ExpirationDate"
+            }
+        },
+        "AcceptedDate": {
+            "type": "column",
+            "mapping": {
+                "destination": "AcceptedDate"
+            }
+        },
+        "TxnStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "TxnStatus"
+            }
+        },
+        "CurrencyRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Currency"
+            }
+        },
+        "ExchangeRate": {
+            "type": "column",
+            "mapping": {
+                "destination": "ExchangeRate"
+            }
+        },
+        "GlobalTaxCalculation": {
+            "type": "column",
+            "mapping": {
+                "destination": "GlobalTaxCalculation"
+            }
+        },
+        "TotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "TotalAmount"
+            }
+        },
+        "HomeTotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "HomeTotalAmount"
+            }
+        },
+        "PrintStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "PrintStatus"
+            }
+        },
+        "EmailStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "EmailStatus"
+            }
+        },
+        "BillEmail.Address": {
+            "type": "column",
+            "mapping": {
+                "destination": "BillEmail_Address"
+            }
+        },
+        "BillAddr": {
+            "type": "table",
+            "destination": "Estimate-BillAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "BillAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "ShipAddr": {
+            "type": "table",
+            "destination": "Estimate-ShipAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ShipAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "Line": {
+            "type": "table",
+            "destination": "Estimate-Line",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ID",
+                        "primaryKey": true
+                    }
+                },
+                "LineNum": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "LineNum"
+                    }
+                },
+                "Description": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Description"
+                    }
+                },
+                "Amount": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Amount"
+                    }
+                },
+                "DetailType": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "DetailType"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_ID"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_name"
+                    }
+                },
+                "SalesItemLineDetail.UnitPrice": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "UnitPrice"
+                    }
+                },
+                "SalesItemLineDetail.Qty": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Qty"
+                    }
+                },
+                "SalesItemLineDetail.TaxCodeRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TaxCode"
+                    }
+                }
+            }
+        },
+        "TxnTaxDetail": {
+            "type": "table",
+            "destination": "Estimate-TxnTaxDetail",
+            "tableMapping": {
+                "TotalTax": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TotalTax"
+                    }
+                },
+                "TaxLine": {
+                    "type": "table",
+                    "destination": "Estimate-TxnTaxDetail-TaxLine",
+                    "tableMapping": {
+                        "Amount": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "Amount"
+                            }
+                        },
+                        "DetailType": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "DetailType"
+                            }
+                        },
+                        "TaxLineDetail.TaxRateRef.value": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxRate_ID",
+                                "primaryKey": true
+                            }
+                        },
+                        "TaxLineDetail.TaxPercent": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxPercent"
+                            }
+                        },
+                        "TaxLineDetail.NetAmountTaxable": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "NetAmountTaxable"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "LinkedTxn": {
+            "type": "table",
+            "destination": "Estimate-LinkedTxn",
+            "tableMapping": {
+                "TxnId": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TxnID",
+                        "primaryKey": true
+                    }
+                },
+                "TxnType": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TxnType"
+                    }
+                }
+            }
+        },
+        "CustomField": {
+            "type": "table",
+            "destination": "Estimate-CustomField",
+            "tableMapping": {
+                "DefinitionId": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Definition_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Name"
+                    }
+                },
+                "Type": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Type"
+                    }
+                },
+                "StringValue": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "StringValue"
+                    }
+                }
+            }
+        }
+    },
+    "CreditMemo": {
+        "Id": {
+            "type": "column",
+            "mapping": {
+                "destination": "ID",
+                "primaryKey": true
+            }
+        },
+        "CustomerRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_ID"
+            }
+        },
+        "CustomerRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_name"
+            }
+        },
+        "DocNumber": {
+            "type": "column",
+            "mapping": {
+                "destination": "DocNumber"
+            }
+        },
+        "TxnDate": {
+            "type": "column",
+            "mapping": {
+                "destination": "TxnDate"
+            }
+        },
+        "CurrencyRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Currency"
+            }
+        },
+        "ExchangeRate": {
+            "type": "column",
+            "mapping": {
+                "destination": "ExchangeRate"
+            }
+        },
+        "GlobalTaxCalculation": {
+            "type": "column",
+            "mapping": {
+                "destination": "GlobalTaxCalculation"
+            }
+        },
+        "TotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "TotalAmount"
+            }
+        },
+        "HomeTotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "HomeTotalAmount"
+            }
+        },
+        "PrintStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "PrintStatus"
+            }
+        },
+        "EmailStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "EmailStatus"
+            }
+        },
+        "BillEmail.Address": {
+            "type": "column",
+            "mapping": {
+                "destination": "BillEmail_Address"
+            }
+        },
+        "Balance": {
+            "type": "column",
+            "mapping": {
+                "destination": "Balance"
+            }
+        },
+        "RemainingCredit": {
+            "type": "column",
+            "mapping": {
+                "destination": "RemainingCredit"
+            }
+        },
+        "BillAddr": {
+            "type": "table",
+            "destination": "CreditMemo-BillAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "BillAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "ShipAddr": {
+            "type": "table",
+            "destination": "CreditMemo-ShipAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ShipAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "Line": {
+            "type": "table",
+            "destination": "CreditMemo-Line",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ID",
+                        "primaryKey": true
+                    }
+                },
+                "LineNum": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "LineNum"
+                    }
+                },
+                "Description": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Description"
+                    }
+                },
+                "Amount": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Amount"
+                    }
+                },
+                "DetailType": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "DetailType"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_ID"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_name"
+                    }
+                },
+                "SalesItemLineDetail.UnitPrice": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "UnitPrice"
+                    }
+                },
+                "SalesItemLineDetail.Qty": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Qty"
+                    }
+                },
+                "SalesItemLineDetail.TaxCodeRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TaxCode"
+                    }
+                }
+            }
+        },
+        "TxnTaxDetail": {
+            "type": "table",
+            "destination": "CreditMemo-TxnTaxDetail",
+            "tableMapping": {
+                "TotalTax": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TotalTax"
+                    }
+                },
+                "TaxLine": {
+                    "type": "table",
+                    "destination": "CreditMemo-TxnTaxDetail-TaxLine",
+                    "tableMapping": {
+                        "Amount": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "Amount"
+                            }
+                        },
+                        "DetailType": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "DetailType"
+                            }
+                        },
+                        "TaxLineDetail.TaxRateRef.value": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxRate_ID",
+                                "primaryKey": true
+                            }
+                        },
+                        "TaxLineDetail.TaxPercent": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxPercent"
+                            }
+                        },
+                        "TaxLineDetail.NetAmountTaxable": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "NetAmountTaxable"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "CustomField": {
+            "type": "table",
+            "destination": "CreditMemo-CustomField",
+            "tableMapping": {
+                "DefinitionId": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Definition_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Name"
+                    }
+                },
+                "Type": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Type"
+                    }
+                },
+                "StringValue": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "StringValue"
+                    }
+                }
+            }
+        }
+    },
+    "RefundReceipt": {
+        "Id": {
+            "type": "column",
+            "mapping": {
+                "destination": "ID",
+                "primaryKey": true
+            }
+        },
+        "CustomerRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_ID"
+            }
+        },
+        "CustomerRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "Customer_name"
+            }
+        },
+        "DocNumber": {
+            "type": "column",
+            "mapping": {
+                "destination": "DocNumber"
+            }
+        },
+        "TxnDate": {
+            "type": "column",
+            "mapping": {
+                "destination": "TxnDate"
+            }
+        },
+        "CurrencyRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "Currency"
+            }
+        },
+        "ExchangeRate": {
+            "type": "column",
+            "mapping": {
+                "destination": "ExchangeRate"
+            }
+        },
+        "GlobalTaxCalculation": {
+            "type": "column",
+            "mapping": {
+                "destination": "GlobalTaxCalculation"
+            }
+        },
+        "TotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "TotalAmount"
+            }
+        },
+        "HomeTotalAmt": {
+            "type": "column",
+            "mapping": {
+                "destination": "HomeTotalAmount"
+            }
+        },
+        "PrintStatus": {
+            "type": "column",
+            "mapping": {
+                "destination": "PrintStatus"
+            }
+        },
+        "PaymentMethodRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "PaymentMethod_ID"
+            }
+        },
+        "PaymentMethodRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "PaymentMethod_name"
+            }
+        },
+        "DepositToAccountRef.value": {
+            "type": "column",
+            "mapping": {
+                "destination": "DepositToAccount_ID"
+            }
+        },
+        "DepositToAccountRef.name": {
+            "type": "column",
+            "mapping": {
+                "destination": "DepositToAccount_name"
+            }
+        },
+        "BillAddr": {
+            "type": "table",
+            "destination": "RefundReceipt-BillAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "BillAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "ShipAddr": {
+            "type": "table",
+            "destination": "RefundReceipt-ShipAddr",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ShipAddr_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Line1": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Line_1"
+                    }
+                },
+                "City": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "City"
+                    }
+                },
+                "CountrySubDivisionCode": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "State"
+                    }
+                }
+            }
+        },
+        "Line": {
+            "type": "table",
+            "destination": "RefundReceipt-Line",
+            "tableMapping": {
+                "Id": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "ID",
+                        "primaryKey": true
+                    }
+                },
+                "LineNum": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "LineNum"
+                    }
+                },
+                "Description": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Description"
+                    }
+                },
+                "Amount": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Amount"
+                    }
+                },
+                "DetailType": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "DetailType"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_ID"
+                    }
+                },
+                "SalesItemLineDetail.ItemRef.name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "SalesItem_name"
+                    }
+                },
+                "SalesItemLineDetail.UnitPrice": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "UnitPrice"
+                    }
+                },
+                "SalesItemLineDetail.Qty": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Qty"
+                    }
+                },
+                "SalesItemLineDetail.TaxCodeRef.value": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TaxCode"
+                    }
+                }
+            }
+        },
+        "TxnTaxDetail": {
+            "type": "table",
+            "destination": "RefundReceipt-TxnTaxDetail",
+            "tableMapping": {
+                "TotalTax": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "TotalTax"
+                    }
+                },
+                "TaxLine": {
+                    "type": "table",
+                    "destination": "RefundReceipt-TxnTaxDetail-TaxLine",
+                    "tableMapping": {
+                        "Amount": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "Amount"
+                            }
+                        },
+                        "DetailType": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "DetailType"
+                            }
+                        },
+                        "TaxLineDetail.TaxRateRef.value": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxRate_ID",
+                                "primaryKey": true
+                            }
+                        },
+                        "TaxLineDetail.TaxPercent": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "TaxPercent"
+                            }
+                        },
+                        "TaxLineDetail.NetAmountTaxable": {
+                            "type": "column",
+                            "mapping": {
+                                "destination": "NetAmountTaxable"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "CustomField": {
+            "type": "table",
+            "destination": "RefundReceipt-CustomField",
+            "tableMapping": {
+                "DefinitionId": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Definition_ID",
+                        "primaryKey": true
+                    }
+                },
+                "Name": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Name"
+                    }
+                },
+                "Type": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "Type"
+                    }
+                },
+                "StringValue": {
+                    "type": "column",
+                    "mapping": {
+                        "destination": "StringValue"
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds CustomField support for QuickBooks sales transaction entities and introduces four new entity mappings that were previously missing from the extractor.

**CustomField support added for:**
- Invoice (existing entity, CustomField mapping added)
- SalesReceipt (new entity)
- Estimate (new entity)
- CreditMemo (new entity)
- RefundReceipt (new entity)

Each `*-CustomField` table follows the existing `PurchaseOrder-CustomField` pattern with columns:
- `Definition_ID` (primary key)
- `Name`
- `Type`
- `StringValue`

**New entity mappings** include full field extraction with nested tables for BillAddr, ShipAddr, Line, TxnTaxDetail, and CustomField.

**API change:** Updated `minorversion` parameter from `65` to `75` in all QuickBooks API requests. User testing confirmed that `minorversion=75` is required for the QuickBooks API to return CustomField data in query responses.

**Bug fix:** Fixed encryption API URL construction that was producing `encryption.keboola.com.com` (duplicate `.com` suffix) instead of `encryption.keboola.com`. This was causing SSL handshake failures when saving OAuth tokens.

## Updates since last revision

- Added four new entity mappings (SalesReceipt, Estimate, CreditMemo, RefundReceipt) with full field extraction and CustomField support
- Fixed encryption API URL bug in `component.py` line 222: changed `f"https://encryption.{URL_SUFFIX}.com/encrypt"` to `f"https://encryption.{URL_SUFFIX}/encrypt"` (the `URL_SUFFIX` already contains `.com`)

## Review & Testing Checklist for Human

- [ ] **Verify encryption API URL fix**: The URL was changed from `encryption.{URL_SUFFIX}.com` to `encryption.{URL_SUFFIX}`. Confirm this produces correct URLs for all Keboola stacks (e.g., `encryption.keboola.com`, `encryption.eu-central-1.keboola.com`).
- [ ] **Verify minorversion=75 doesn't break existing endpoints**: This parameter is now applied globally to all API requests. Test that existing endpoints (e.g., Invoice, PurchaseOrder, Customer, reports) still work correctly.
- [ ] **Test new entity extraction**: The four new entities (SalesReceipt, Estimate, CreditMemo, RefundReceipt) have not been tested against real QuickBooks data. Verify they extract correctly.
- [ ] **Verify CustomField extraction for Invoice**: Confirmed working in sandbox testing. Verify in production-like environment.
- [ ] **Test CustomField for new entities**: The CustomField mapping assumes the same structure across all sales transaction types. Verify this assumption holds.

### Test Plan
1. Configure extractor with a QuickBooks sandbox account
2. Test Invoice CustomField extraction (already verified working)
3. Create test data for SalesReceipt, Estimate, CreditMemo, and RefundReceipt in QuickBooks
4. Run the extractor with the new image tag for each new entity
5. Verify tables are created with correct data and nested relationships
6. Run extraction for existing endpoints to verify no regressions
7. Verify OAuth token refresh works correctly (tests encryption API fix)

### Notes

- Invoice CustomField extraction was tested and confirmed working in sandbox (Job 33796125)
- The new entity mappings follow the same pattern as Invoice but have not been tested with real QuickBooks data
- QuickBooks legacy REST API only exposes the first 3 String custom fields configured in `Preferences.SalesFormsPrefs.CustomField`
- The encryption URL bug was discovered while debugging job 1283162140 which showed SSL errors connecting to `encryption.keboola.com.com`

**Link to Devin run**: https://app.devin.ai/sessions/5c6672388ad14f89990cece4173cb2a2
**Requested by**: zdenek.srotyr@keboola.com (@ZdenekSrotyr)