### PR TITLE
[CFTL-700] Fix QuickBooks OOM on large endpoints + OAuth token persistence

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -21,7 +21,7 @@ class QuickbooksClient:
     QuickBooks Requests Handler
     """
 
-    def __init__(self, company_id, access_token, refresh_token, oauth, sandbox):
+    def __init__(self, company_id, access_token, refresh_token, oauth, sandbox, on_token_refresh=None):
         self.data_2 = None
         self.data = None
         self.app_key = oauth.appKey
@@ -38,6 +38,9 @@ class QuickbooksClient:
         self.access_token_refreshed = False
         self.new_refresh_token = False
         self.company_id = company_id
+        # Optional callback fired whenever the access/refresh token is rotated, so the
+        # caller can persist the new tokens immediately (QuickBooks rotates them).
+        self.on_token_refresh = on_token_refresh
         self.reports_required_accounting_type = [
             "ProfitAndLoss",
             "ProfitAndLossDetail",
@@ -90,12 +93,11 @@ class QuickbooksClient:
                     raise QuickBooksClientException(f"Start date and End date are required for {endpoint} reports.")
                 self.report_request(endpoint, start_date, end_date, params)
         else:
-            self.count = self.get_count()  # total count of records for pagination
+            # Data endpoints are streamed page-by-page by the caller via data_request().
+            # Here we only resolve the total record count used to drive pagination.
+            self.count = self.get_count()
             if self.count == 0:
                 logging.info("There are no returns for {0}".format(self.endpoint))
-                self.data = []
-            else:
-                self.data_request()
 
     @backoff.on_exception(backoff.expo, HTTPError, max_tries=3)
     def refresh_access_token(self):
@@ -121,6 +123,8 @@ class QuickbooksClient:
         self.access_token = results["access_token"]
         self.refresh_token = results["refresh_token"]
         self.access_token_refreshed = True
+        if self.on_token_refresh:
+            self.on_token_refresh(self.refresh_token, self.access_token)
 
     def get_count(self):
         """
@@ -182,7 +186,10 @@ class QuickbooksClient:
 
     def data_request(self):
         """
-        Handles Request Parameters and Pagination
+        Generator that yields one page of records (~maxresults) at a time.
+
+        Streaming pages instead of accumulating them keeps peak memory at O(page_size)
+        regardless of the total record count (SUPPORT-16682).
         """
 
         num_of_run = 0
@@ -213,10 +220,11 @@ class QuickbooksClient:
 
             data = results["QueryResponse"][self.endpoint]
 
-            # Concatenate with exist extracted data
-            self.data = self.data + data
+            # Yield this page so the caller can flush it to disk and release it,
+            # keeping memory usage constant instead of growing with total records.
+            yield data
 
-            # Handling pagination paramters
+            # Handling pagination parameters
             self.startposition += self.maxresults
             num_of_run += 1
 

--- a/src/component.py
+++ b/src/component.py
@@ -5,7 +5,7 @@ import requests
 import backoff
 import json
 
-from mapping import Mapping
+from mapping import Mapping, TableStreamWriter
 from client import QuickbooksClient, QuickBooksClientException
 from report_mapping import ReportMapping
 from datetime import date
@@ -84,25 +84,21 @@ class Component(ComponentBase):
             params.get(KEY_SUMMARIZE_COLUMN_BY) if params.get(KEY_SUMMARIZE_COLUMN_BY) else self.summarize_column_by
         )
 
-        self.write_state_file(
-            {
-                "tokens": {
-                    "ts": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                    "#refresh_token": self.refresh_token,
-                    "#access_token": self.access_token,
-                }
-            }
-        )
-
         quickbooks_param = QuickbooksClient(
             company_id=company_id,
             refresh_token=self.refresh_token,
             access_token=self.access_token,
             oauth=oauth,
             sandbox=sandbox,
+            on_token_refresh=self._on_token_refresh,
         )
 
         self.process_oauth_tokens(quickbooks_param)
+
+        # Persist the (possibly rotated) tokens AFTER the refresh, not before. QuickBooks
+        # rotates the refresh token and immediately invalidates the previous one, so saving
+        # the stale pre-refresh tokens would break the next run (SUPPORT-15835).
+        self._save_tokens_to_state_file()
 
         # Fetching reports for each configured endpoint
         for endpoint in endpoints:
@@ -118,32 +114,39 @@ class Component(ComponentBase):
             self.fetch(quickbooks_param=quickbooks_param, endpoint=endpoint, report_api_bool=report_api_bool)
 
             # Phase 2: Mapping
-            # Translate Input JSON file into CSV with configured mapping
-            # For different accounting_type,
-            # input_data will be outputting Accrual Type
-            # input_data_2 will be outputting Cash Type
+            # Translate the API results into CSV using the configured mapping.
             logging.info("Parsing API results...")
-            input_data = quickbooks_param.data
 
-            # if there are no data
-            # output blank
-            if len(input_data) == 0:
-                pass
-            else:
-                logging.info("Report API Template Enable: {0}".format(report_api_bool))
-                if report_api_bool:
+            if report_api_bool:
+                # Report endpoints return a single, non-paginated response.
+                # For accounting-type reports: data = Accrual, data_2 = Cash.
+                input_data = quickbooks_param.data
+                if len(input_data) == 0:
+                    pass
+                else:
+                    logging.info("Report API Template Enable: {0}".format(report_api_bool))
                     if endpoint == "CustomQuery":
                         # Not implemented
                         ReportMapping(endpoint=endpoint, data=input_data, query=self.start_date)
+                    elif endpoint in quickbooks_param.reports_required_accounting_type:
+                        input_data_2 = quickbooks_param.data_2
+                        ReportMapping(endpoint=endpoint, data=input_data, accounting_type="accrual")
+                        ReportMapping(endpoint=endpoint, data=input_data_2, accounting_type="cash")
                     else:
-                        if endpoint in quickbooks_param.reports_required_accounting_type:
-                            input_data_2 = quickbooks_param.data_2
-                            ReportMapping(endpoint=endpoint, data=input_data, accounting_type="accrual")
-                            ReportMapping(endpoint=endpoint, data=input_data_2, accounting_type="cash")
-                        else:
-                            ReportMapping(endpoint=endpoint, data=input_data)
+                        ReportMapping(endpoint=endpoint, data=input_data)
+            else:
+                # Data endpoints are paginated: stream each page straight to disk through
+                # a shared writer and release it, so peak memory stays at O(page_size)
+                # instead of growing with the total record count (SUPPORT-16682).
+                if quickbooks_param.count == 0:
+                    pass
                 else:
-                    Mapping(endpoint=endpoint, data=input_data)
+                    writer = TableStreamWriter()
+                    try:
+                        for page in quickbooks_param.data_request():
+                            Mapping(endpoint=endpoint, data=page, writer=writer)
+                    finally:
+                        writer.close()
 
     def get_tokens(self, oauth):
         try:
@@ -168,14 +171,37 @@ class Component(ComponentBase):
 
         return refresh_token, access_token
 
+    def _on_token_refresh(self, new_refresh_token: str, new_access_token: str) -> None:
+        """Callback fired by the client the moment tokens are rotated, so the new tokens
+        are persisted to the state file immediately - even if the run fails afterwards."""
+        self.refresh_token = new_refresh_token
+        self.access_token = new_access_token
+        self._save_tokens_to_state_file()
+
+    def _save_tokens_to_state_file(self) -> None:
+        """Writes the current tokens to the output state file so they persist for the next run."""
+        self.write_state_file(
+            {
+                "tokens": {
+                    "ts": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                    "#refresh_token": self.refresh_token,
+                    "#access_token": self.access_token,
+                }
+            }
+        )
+
     def process_oauth_tokens(self, client) -> None:
         """Uses Quickbooks client to get new tokens and saves them using API if they have changed since the last run."""
+        # Capture the token before the refresh: the on_token_refresh callback mutates
+        # self.refresh_token during get_new_refresh_token(), so comparing against
+        # self.refresh_token afterwards would always be False and skip the API save.
+        original_refresh_token = self.refresh_token
         new_refresh_token, new_access_token = client.get_new_refresh_token()
-        if self.refresh_token != new_refresh_token:
+        if original_refresh_token != new_refresh_token:
             self.save_new_oauth_tokens(new_refresh_token, new_access_token)
 
-            # We also save new tokens to class vars, so we can save them unencrypted if case statefile update fails
-            # in update_config_state() method.
+            # Also keep the new tokens on the class vars so the state-file save below
+            # persists them even if the encrypted update_config_state() API call failed.
             self.refresh_token = new_refresh_token
             self.access_token = new_access_token
 
@@ -219,7 +245,7 @@ class Component(ComponentBase):
 
     @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=5)
     def encrypt(self, token: str) -> str:
-        url = f"https://encryption.{URL_SUFFIX}.com/encrypt"
+        url = f"https://encryption.{URL_SUFFIX}/encrypt"
         params = {
             "componentId": self.environment_variables.component_id,
             "projectId": self.environment_variables.project_id,

--- a/src/mapping.py
+++ b/src/mapping.py
@@ -1,3 +1,4 @@
+import csv
 import uuid
 import pandas as pd
 import json
@@ -12,13 +13,67 @@ DEFAULT_FILE_INPUT = os.path.join(cwd_parent, "data/in/tables/")
 DEFAULT_FILE_DESTINATION = os.path.join(cwd_parent, "data/out/tables/")
 
 
+class TableStreamWriter:
+    """
+    Holds one open CSV writer per output table for the duration of a single endpoint's
+    pagination, so each table's header and column order are established once - on the
+    first page that produces rows for that table - and reused for every later page.
+
+    This is what lets the data endpoints stream: each page is parsed, appended through
+    this writer, and discarded, so peak memory stays at O(page_size) instead of growing
+    with the total record count.
+
+    The column set is taken from the first row of each table. The mapping (mappings.json)
+    drives parsing, so every row of a given table carries the exact same keys in the same
+    order - the first row is therefore the complete, correctly ordered header. We still
+    pass ``extrasaction="ignore"`` and ``restval=""`` as a safety net so an unexpected
+    key never shifts columns or raises.
+    """
+
+    def __init__(self, destination=DEFAULT_FILE_DESTINATION):
+        self.destination = destination
+        self._files = {}
+        self._writers = {}
+
+    def write_rows(self, table_name, rows):
+        if not rows:
+            return
+        for row in rows:
+            writer = self._get_writer(table_name, row)
+            writer.writerow(row)
+
+    def _get_writer(self, table_name, sample_row):
+        if table_name not in self._writers:
+            file_dest = self.destination + table_name + ".csv"
+            file_handle = open(file_dest, "w", newline="")
+            writer = csv.DictWriter(
+                file_handle,
+                fieldnames=list(sample_row.keys()),
+                extrasaction="ignore",
+                restval="",
+                lineterminator="\n",
+            )
+            writer.writeheader()
+            self._files[table_name] = file_handle
+            self._writers[table_name] = writer
+            logging.info("Streaming table output: {0}...".format(file_dest))
+        return self._writers[table_name]
+
+    def close(self):
+        for file_handle in self._files.values():
+            file_handle.close()
+        self._files.clear()
+        self._writers.clear()
+
+
 class Mapping:
     """
     Handling Generic Ex Mapping
     """
 
-    def __init__(self, endpoint, data):
+    def __init__(self, endpoint, data, writer=None):
         self.endpoint = endpoint
+        self.writer = writer
         self.mapping = self.mapping_check(self.endpoint)
         self.out_file = {self.endpoint: []}
         self.out_file_pk = {self.endpoint: []}  # destination name from mapping
@@ -223,17 +278,25 @@ class Mapping:
 
     def output(self):
         """
-        Output Data with its desired file name
+        Output Data with its desired file name.
+
+        When a streaming ``writer`` is supplied (the default for paginated data
+        endpoints) each table's rows are appended through it, so the full dataset is
+        never materialised in memory. Without a writer the legacy single-shot behaviour
+        is kept for backward compatibility.
         """
 
-        # Outputting files
         out_file = self.out_file
 
-        for file in out_file:
-            out_df = pd.DataFrame(out_file[file])
-            file_dest = DEFAULT_FILE_DESTINATION + file + ".csv"
-            out_df.to_csv(file_dest, index=False)
-            logging.info("Table output: {0}...".format(file_dest))
+        if self.writer is not None:
+            for table_name in out_file:
+                self.writer.write_rows(table_name, out_file[table_name])
+        else:
+            for file in out_file:
+                out_df = pd.DataFrame(out_file[file])
+                file_dest = DEFAULT_FILE_DESTINATION + file + ".csv"
+                out_df.to_csv(file_dest, index=False)
+                logging.info("Table output: {0}...".format(file_dest))
 
         # Outputting manifest file if incremental
         out_file_pk = self.out_file_pk  # noqa

--- a/tests/test_streaming_mapping.py
+++ b/tests/test_streaming_mapping.py
@@ -1,0 +1,226 @@
+"""
+Regression tests for the per-page streaming output path (SUPPORT-16682).
+
+The OOM fix replaced the "accumulate every page in memory, then write once" pattern
+with a generator that yields one page at a time, flushed straight to disk through a
+shared ``TableStreamWriter``. These tests guard the two properties that refactor must
+not break:
+
+1. Pagination invariance - splitting the same records across several pages produces
+   BYTE-IDENTICAL output to processing them all at once. This is the core risk: that
+   chunking + append-mode writing could drop rows, duplicate headers, or misalign
+   columns (e.g. when a nested sub-table first appears only on a later page).
+
+2. Parity with the legacy path - the streamed output is logically identical (same
+   tables, same column order, same rows) to the original accumulate-then-write
+   implementation that shipped to customers.
+
+The fixture is built around the ``Purchase`` endpoint (the one that OOMed in the
+ticket) precisely because it has nested sub-tables that appear sparsely: page 1 has
+no line items at all, so ``Purchase-Line`` and friends are first created mid-stream
+on page 2.
+"""
+
+import csv
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+# The component uses flat imports (``from mapping import ...``); put ``src`` on the path.
+SRC_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src")
+sys.path.insert(0, SRC_DIR)
+
+import mapping  # noqa: E402
+from mapping import Mapping, TableStreamWriter  # noqa: E402
+
+ENDPOINT = "Purchase"
+
+
+def _purchase(pid, **extra):
+    """Builds a minimal-but-realistic Purchase API record; ``extra`` overrides/adds fields."""
+    record = {
+        "Id": pid,
+        "AccountRef": {"value": "33", "name": "Checking"},
+        "PaymentType": "Cash",
+        "TotalAmt": 100,
+        "MetaData": {"CreateTime": "2024-01-01T00:00:00-08:00", "LastUpdatedTime": "2024-01-02T00:00:00-08:00"},
+        "TxnDate": "2024-01-01",
+        "CurrencyRef": {"value": "USD"},
+    }
+    record.update(extra)
+    return record
+
+
+def _line(line_id, description, amount):
+    return {
+        "Id": line_id,
+        "Description": description,
+        "Amount": amount,
+        "DetailType": "AccountBasedExpenseLineDetail",
+        "AccountBasedExpenseLineDetail": {
+            "AccountRef": {"value": "7", "name": "Expenses"},
+            "BillableStatus": "NotBillable",
+        },
+    }
+
+
+def build_pages():
+    """
+    Three pages where the nested sub-tables only appear from page 2 onwards - this is
+    the column-misalignment trap the streaming writer must survive.
+    """
+    page1 = [
+        # No line items, no tax detail, missing optional PrivateNote (sparse row).
+        _purchase("1001", TotalAmt=100),
+        # PrivateNote contains a comma + quote to exercise CSV quoting.
+        _purchase("1002", TotalAmt=250.5, PrivateNote='note, with "comma"'),
+    ]
+    page2 = [
+        _purchase("1003", TotalAmt=75, Line=[_line("1", "Item A", 50), _line("2", "Item B", 25)]),
+        _purchase(
+            "1004",
+            TotalAmt=312.5,
+            Line=[_line("1", "Only line", 300)],
+            TxnTaxDetail={
+                "TotalTax": 12.5,
+                "TaxLine": [
+                    {
+                        "Amount": 12.5,
+                        "DetailType": "TaxLineDetail",
+                        "TaxLineDetail": {"PercentBased": True, "TaxPercent": 5, "NetAmountTaxable": 250},
+                    }
+                ],
+            },
+        ),
+    ]
+    page3 = [
+        _purchase("1005", TotalAmt=42, Line=[_line("1", "Late page item", 42)]),
+    ]
+    return [page1, page2, page3]
+
+
+class _DeterministicUUID:
+    """Replacement for uuid.uuid4 that yields a stable, repeatable sequence.
+
+    Sub-table primary keys are built from ``uuid4().hex``. To compare two runs we need
+    the same records (in the same order) to produce the same keys, so each run gets a
+    fresh instance whose counter starts at zero.
+    """
+
+    def __init__(self):
+        self.n = 0
+
+    def __call__(self):
+        value = types.SimpleNamespace(hex=f"uuid{self.n:06d}")
+        self.n += 1
+        return value
+
+
+def _run_streaming(pages, out_dir):
+    writer = TableStreamWriter(destination=out_dir + os.sep)
+    with mock.patch("mapping.uuid.uuid4", new=_DeterministicUUID()):
+        try:
+            for page in pages:
+                Mapping(endpoint=ENDPOINT, data=page, writer=writer)
+        finally:
+            writer.close()
+
+
+def _run_legacy(rows, out_dir):
+    # The legacy path reads the module-level destination constant directly.
+    with mock.patch.object(mapping, "DEFAULT_FILE_DESTINATION", out_dir + os.sep), mock.patch(
+        "mapping.uuid.uuid4", new=_DeterministicUUID()
+    ):
+        Mapping(endpoint=ENDPOINT, data=rows)  # no writer -> legacy pandas single-shot
+
+
+def _read_table(path):
+    with open(path, newline="") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+    header = rows[0] if rows else []
+    data = rows[1:] if len(rows) > 1 else []
+    return header, data
+
+
+def _read_dir(out_dir):
+    return {name for name in os.listdir(out_dir) if name.endswith(".csv")}
+
+
+def _norm_cell(value):
+    """Normalises a CSV cell so int/float formatting differences (pandas '75.0' vs
+    csv '75') don't cause spurious mismatches when comparing against the legacy path."""
+    try:
+        return ("num", float(value))
+    except (TypeError, ValueError):
+        return ("str", value)
+
+
+def _norm_rows(rows):
+    return [[_norm_cell(c) for c in row] for row in rows]
+
+
+class StreamingMappingTest(unittest.TestCase):
+    def setUp(self):
+        self.pages = build_pages()
+        self.all_rows = [r for page in self.pages for r in page]
+
+    def test_pagination_is_byte_identical_to_single_shot(self):
+        """Streaming records across 3 pages == streaming them all in one page, byte-for-byte."""
+        with tempfile.TemporaryDirectory() as paged_dir, tempfile.TemporaryDirectory() as single_dir:
+            _run_streaming(self.pages, paged_dir)
+            _run_streaming([self.all_rows], single_dir)
+
+            self.assertEqual(_read_dir(paged_dir), _read_dir(single_dir), "different set of output tables")
+            self.assertTrue(_read_dir(paged_dir), "no output tables were produced")
+
+            for name in _read_dir(paged_dir):
+                with open(os.path.join(paged_dir, name), "rb") as a, open(os.path.join(single_dir, name), "rb") as b:
+                    self.assertEqual(a.read(), b.read(), f"{name} differs between paged and single-shot streaming")
+
+    def test_late_appearing_subtable_has_one_header(self):
+        """A sub-table first produced on page 2 must still have exactly one header row."""
+        with tempfile.TemporaryDirectory() as out_dir:
+            _run_streaming(self.pages, out_dir)
+            line_path = os.path.join(out_dir, "Purchase-Line.csv")
+            self.assertTrue(os.path.exists(line_path), "Purchase-Line.csv was not created")
+            header, data = _read_table(line_path)
+            # Header is the mapping's destinations + the parent-table FK.
+            self.assertIn("parent_table", header)
+            self.assertEqual(len(header), len(set(header)), "duplicate columns in header")
+            # 3 line items total (2 on page 2 record 1003, 1 on 1004, 1 on page 3) -> 4 rows.
+            self.assertEqual(len(data), 4)
+            # No stray header rows leaked into the data (append-mode regression guard).
+            self.assertNotIn(header, data)
+
+    def test_streaming_matches_legacy_output(self):
+        """Streamed output is logically identical to the original accumulate-then-write path."""
+        with tempfile.TemporaryDirectory() as stream_dir, tempfile.TemporaryDirectory() as legacy_dir:
+            _run_streaming([self.all_rows], stream_dir)
+            _run_legacy(self.all_rows, legacy_dir)
+
+            self.assertEqual(_read_dir(stream_dir), _read_dir(legacy_dir), "different set of output tables")
+
+            for name in _read_dir(stream_dir):
+                stream_header, stream_rows = _read_table(os.path.join(stream_dir, name))
+                legacy_header, legacy_rows = _read_table(os.path.join(legacy_dir, name))
+                self.assertEqual(stream_header, legacy_header, f"{name}: column set/order differs from legacy")
+                self.assertEqual(
+                    _norm_rows(stream_rows),
+                    _norm_rows(legacy_rows),
+                    f"{name}: row content differs from legacy",
+                )
+
+    def test_root_table_row_count(self):
+        """Sanity: every Purchase record reaches the root output table exactly once."""
+        with tempfile.TemporaryDirectory() as out_dir:
+            _run_streaming(self.pages, out_dir)
+            _, data = _read_table(os.path.join(out_dir, "Purchase.csv"))
+            self.assertEqual(len(data), len(self.all_rows))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two scoped fixes for `keboola.ex-quickbooks-online`. This intentionally **excludes** the unrelated `mappings.json` / CustomField / `minorversion=75` changes bundled into the existing draft PR #6 — those are a separate concern and should ship on their own.

### 1. OOM on large data endpoints (SUPPORT-16682)
The component accumulated every paginated page in memory (`self.data` list), re-parsed it into a dict, then built a full `pandas.DataFrame` before writing — three full-dataset copies, so memory grew with total record count and jobs were killed at 512M while paginating large entities.

- `client.data_request()` is now a **generator** yielding one ~1000-record page at a time.
- `component.run()` iterates the generator and flushes each page straight to disk, then releases it → peak memory is **O(page_size)** instead of O(total_records).
- New `mapping.TableStreamWriter` holds one `csv.DictWriter` per output table for the whole endpoint, fixing header/column order on first appearance. This also removes the per-page column-misalignment risk of a per-page `DataFrame.to_csv(mode="a")` append (where pandas infers columns per page).
- **Report endpoints (single, non-paginated response) are intentionally unchanged.**

### 2. OAuth token persistence (SUPPORT-15835)
The component wrote tokens to the Keboola state file **before** the OAuth refresh, persisting the stale pre-refresh refresh token. Intuit rotates and immediately invalidates the previous refresh token, so the next run read a dead token and failed with `400` at the Intuit token endpoint, forcing manual re-authorization.

- Persist tokens to state **after** the refresh.
- Add an `on_token_refresh` callback so a rotated token is persisted the moment it changes (also covers mid-run refreshes).
- Capture the original refresh token before the refresh so the "did it change?" comparison is correct (the callback mutates `self.refresh_token`).
- Fix the encryption API URL typo: `encryption.{suffix}.com` → `encryption.{suffix}` (master was building `encryption.keboola.com.com`).

## Tests
First tests in this repo. `tests/test_streaming_mapping.py` proves:
- Paginated output is **byte-identical** to single-shot streaming (pagination invariance).
- A sub-table first produced on a later page still has **exactly one header** (append-mode regression guard).
- Streamed output is **parity-equal to the legacy accumulate-then-write path** (same tables, column order, rows).

Runs green via the existing `flake8 + unittest` Docker target (`docker compose run --rm test`): `Ran 4 tests — OK`, flake8 clean.

## Validation (no end-to-end tests yet, so validated against production)
- **OOM:** Datadog shows the crash was on the paginated `Purchase` endpoint (~57k records, `STARTPOSITION 57001`, not a report). After a streaming build deployed, the **same 57k dataset completed** and OOMs went 46 → 0. This PR implements the same streaming approach, hardened with a fixed-fieldname writer and backed by the regression tests above.
- **Token:** a live `400` at `oauth.platform.intuit.com/oauth2/v1/tokens/bearer` on the unpatched prod image matches the stale-rotated-token signature exactly; this fix targets that mechanism.

## Follow-ups (out of scope for this PR)
- Release to the **prod default image** so configs still on the old published version get the token fix (a separate config on the old image still hits the live token bug).
- Report endpoints still materialize their full response in memory — latent OOM risk for very large `GeneralLedger`/`TransactionList` pulls; not addressed here.
- A full VCR/datadir end-to-end test (mocking Intuit OAuth + query API) would complement the mapping-level regression suite.

Refs: CFTL-700, SUPPORT-16682, SUPPORT-15835. Related: draft PR #6 (superseded for these two fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
